### PR TITLE
[16587] Accessibility Fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,10 @@
 <!doctype html>
-<html>
+<html lang="en-US">
   <head>
-    <title>Export.gov/CSL Search</title>
-    <script src="https://code.jquery.com/jquery-3.1.0.slim.min.js"></script>
+    <title>CSL Search</title>
     <script>
-      $(document).ready(function() {
-        Explorer.render('explorer-app');
+      document.addEventListener("DOMContentLoaded", function() {
+        window.Explorer.render('explorer-app');
       });
     </script>
   </head>

--- a/src/components/Form/Form.js
+++ b/src/components/Form/Form.js
@@ -10,13 +10,13 @@ import './Form.scss';
 const TextField = ({ description, input, label, meta: { error } }) => (
   <div className={cx('explorer__form__group', { 'explorer__form__group--error': !!error })}>
     <label htmlFor={input.name}>{label}</label>
-    {description ? <p>{description}</p> : null}
+    {description ? <div>{description}</div> : null}
     <input type="text" className="explorer__form__input" id={input.name} {...input} />
     {(error && <span className="explorer__form__message">{error}</span>)}
   </div>
 );
 TextField.propTypes = {
-  description: PropTypes.string,
+  description: PropTypes.object,
   input: PropTypes.object.isRequired,
   label: PropTypes.string,
   meta: PropTypes.object,
@@ -26,26 +26,23 @@ const onSelectFn = (onChange) => ({
   false: (value) => onChange(value['value']),
   true:  (values) => onChange(map(values, 'value')),
 });
-const SelectField = ({ description, input, label = 'Untitled', name, options, multi = false }) => (
+const SelectField = ({ description, input, label = 'Untitled', options, multi = false }) => (
   <div className="explorer__form__group">
-    <label htmlFor={name}>{label}</label>
-    {description ? <p>{description}</p> : null}
-    <div>
-      <Select
-        {...input}
-        options={options}
-        multi={multi} autoBlur
-        onBlur={() => input.onBlur(input.value)}
-        onChange={onSelectFn(input.onChange)[multi]}
-      />
-    </div>
+    <label htmlFor={label}>{label}</label>
+    {description ? <div>{description}</div> : null}
+    <Select
+      {...input}
+      options={options}
+      multi={multi} autoBlur
+      onBlur={() => input.onBlur(input.value)}
+      onChange={onSelectFn(input.onChange)[multi]}
+    />
   </div>
 );
 SelectField.propTypes = {
-  description: PropTypes.string,
+  description: PropTypes.object,
   input: PropTypes.object.isRequired,
   label: PropTypes.string,
-  name: PropTypes.string.isRequired,
   options: PropTypes.array.isRequired,
   multi: PropTypes.bool,
 };
@@ -55,33 +52,36 @@ const Form = ({
 }) => (
   <form className="explorer__form" onSubmit={handleSubmit}>
     <fieldset>
+      <legend>
+        <p className="DefaultParagraph-1">Search all <a href="https://www.trade.gov/consolidated-screening-list" target="_parent">the screening lists</a> at one time by filling in the search boxes below.  <br/> If you get too many results, try including more information to the additional fields.  If you get too few results, try searching one field at a time.</p>
+      </legend>
       <Field
         component={TextField} name="q" label="Keyword"
-        description="Search for words in the name, alternative names (aliases), title of the entity, and additional remarks regarding the entity."
+        description={<p>Search for words in the name, alternative names (aliases), title of the entity, and additional remarks regarding the entity.</p>}
       />
       <Field
         component={TextField} name="name" label="Name"
-        description="Search for an entity&#39;s name or one of its alternative names."
+        description={<p>Search for an entity&#39;s name or one of its alternative names.</p>}
       />
       <Field
         component={SelectField} name="fuzzyName" label="Fuzzy Name"
         options={[{ label: 'Off', value: '' }, { label: 'On', value: 'true' }]}
         description={<div>
-          <p>When set to off, the spelling of the Name you search for must be correct to get results. When set to on, the spelling for the Name you search for may be slightly off. Check the score for each result to determine how close a match it is to the entity's name or its alternative names. A score of 100 is an exact match. Results are returned with the highest scores first.</p>
-          <p>Fuzzy search filters out the following common words: co, company, corp, corporation, inc, incorporated, limited, ltd, mrs, ms, mr, organization, sa, sas, llc, university, and univ.  For example, 'Water Corporation' returns the same results as 'Water' because 'Corporation' is one of the common words.</p>
+          <p>When set to "off", the spelling of the Name you search for must be correct to get results. When set to "on", the spelling for the Name you search for may be slightly off from the exact spelling. Check the score for each result to determine how close a match it is to the entity's name or its alternative names. A score of 100 is an exact match. Results are returned with the highest scores first.</p>
+          <p>Fuzzy search filters out the following common words: co, company, corp, corporation, inc, incorporated, limited, ltd, mrs, ms, mr, organization, sa, sas, llc, university, and univ.  <br/> For example, 'Water Corporation' returns the same results as 'Water' because 'Corporation' is one of the common words.</p>
         </div>}
       />
       <Field
         component={TextField} name="address" label="Address"
-        description="Search for the street address, city, province, and postal code of an entity."
+        description={<p>Search for the street address, city, province, and postal code of an entity.</p>}
       />
       <Field
         component={SelectField} name="sources" label="Sources" options={sourceList} multi
-        description="Choose which of the screening lists that you want to search."
+        description={<p>Choose which of the screening lists that you want to search.</p>}
       />
       <Field
         component={SelectField} name="countries" label="Countries" options={countryList} multi
-        description="Choose which countries that you want to search. Note, the Nonproliferation Sanctions and ITAR Debarred lists do not include the country with an entity. If you choose to search for entities by country then you will not be searching these two lists."
+        description={<p>Choose which countries that you want to search. Note, the Nonproliferation Sanctions and ITAR Debarred lists do not include the country with an entity. If you choose to search for entities by country then you will not be searching these two lists.</p>}
       />
       <div className="explorer__form__group">
         <button className="explorer__form__submit pure-button pure-button-primary" onClick={handleSubmit} disabled={!!error}>

--- a/src/components/Form/Form.scss
+++ b/src/components/Form/Form.scss
@@ -1,7 +1,7 @@
 @import "./Select.scss";
 
 .explorer__form {
-  font-size: 11px;
+  font-size: 14px;
   margin: 28px 0;
   position: relative;
 
@@ -29,7 +29,6 @@
     }
 
     p {
-      font-size: 11px;
       margin: 0;
       margin-top: -2px;
     }

--- a/src/components/Form/Select.scss
+++ b/src/components/Form/Select.scss
@@ -80,7 +80,7 @@
 .Select-placeholder,
 .Select--single > .Select-control .Select-value {
   bottom: 0;
-  color: #aaa;
+  color: #585858;
   left: 0;
   line-height: 34px;
   padding-left: 10px;

--- a/src/components/Result/Result.scss
+++ b/src/components/Result/Result.scss
@@ -1,5 +1,5 @@
 .explorer__result {
-  font-size: 11px;
+  font-size: 14px;
 
   table {
     width: 100%;
@@ -10,6 +10,7 @@
   margin-top: 10px;
 
   a.explorer__result-item__label {
+    font-size: 14px;
     color: #126aa8;
   }
 
@@ -25,6 +26,7 @@
   }
 
   td {
+    font-size: 13px;
     vertical-align: top;
     &:nth-child(2) {
       word-wrap: break-word;
@@ -43,7 +45,6 @@
 
     td {
       border: 1px solid #cbcbcb;
-      font-size: 11px;
       padding: .5em 1em;
       vertical-align: top;
     }
@@ -86,7 +87,7 @@
     border-radius: 2px;
     cursor: pointer;
     display: inline-block;
-    font-size: 9px;
+    font-size: 12px;
     margin-right: 5px;
     padding: .5em 1em;
     text-decoration: none;

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -4,6 +4,7 @@ import { stringify, parse } from 'querystring';
 import { assign, camelCase, isEmpty, omitBy, reduce, snakeCase } from '../utils/lodash';
 import { Form, Result, Spinner } from '../components';
 import { fetchResultsIfNeeded } from '../actions';
+import a11yFixes from '../utils/a11yFixes';
 import './App.scss';
 
 class App extends Component {
@@ -39,17 +40,15 @@ class App extends Component {
       query,
       (result, value, key) => assign(result, { [camelCase(key)]: value }),
       {});
-    return (
-      <div className="explorer">
-        <h1 className="Header-1"><b>Search the Consolidated Screening List</b></h1>
-        <p className="DefaultParagraph-1">Search <a href="https://www.trade.gov/consolidated-screening-list">the screening lists</a> at one time by filling in the search boxes below.  If you get too many results, try including more information to the additional fields.  If you get too few results, try searching one field at a time.</p>
+    a11yFixes();
 
-        <div className="explorer__content">
-          <Form onSubmit={this.handleSubmit} initialValues={formValues} />
-          <Spinner active={results.isFetching} />
-          <Result results={results} onPaging={this.handlePaging} query={query} />
-        </div>
-      </div>
+    return (
+      <main className="explorer__content">
+        <h1 id="Header-1">Search the Consolidated Screening List</h1>
+        <Form onSubmit={this.handleSubmit} initialValues={formValues} />
+        <Spinner active={results.isFetching} />
+        <Result results={results} onPaging={this.handlePaging} query={query} />
+      </main>
     );
   }
 }

--- a/src/containers/App.scss
+++ b/src/containers/App.scss
@@ -1,25 +1,14 @@
-.explorer {
-  font: 16px/1.5 Lato,"Helvetica Neue",Helvetica,Arial,sans-serif;
+.explorer__content {
+  font: 16px/1.5 Verdana,"Helvetica Neue",Helvetica,Arial,sans-serif;
   font-weight: normal;
   margin: 0 auto;
+  padding: 0 22px;
   position: relative;
   text-align: left;
-  width: 971px;
-
-  &__content {
-    font-family: Verdana;
-    margin: 0 58.5px;
-    max-width: 800px;
-    padding: 0 22px;
-  }
-
-  &__header__banner {
-    height: 102px;
-  }
+  max-width: 971px;
 
   &__result {
     clear: both;
-    font-size: 11px;
   }
 
   &__result-item {

--- a/src/utils/a11yFixes.js
+++ b/src/utils/a11yFixes.js
@@ -1,0 +1,18 @@
+function a11yFixes () {
+  /* correcting some react-select v1 a11y bugs. Not very elegant, but quicker than upgrading everything so we can upgrade that package */
+  window.onload = function () {
+    document.querySelectorAll('[role="combobox"]').forEach(function (el, i){
+      let idText = el.parentNode.parentNode.parentNode.parentNode.parentNode.getElementsByTagName('label')[0].htmlFor
+      el.setAttribute('id', idText)
+    })
+
+    let fuzzyNameSelect = document.querySelector('label[for="Fuzzy Name"]').parentNode.querySelector('span[role="option"]').parentNode
+    fuzzyNameSelect.setAttribute('role', 'listbox')
+    fuzzyNameSelect.setAttribute('aria-label', 'Fuzzy Name toggle')
+
+    /* the Drupal page requires summary text so this isn't needed there (in iframe) */
+    if (window.self !== window.top) { document.getElementById("Header-1").style.display = "none" }
+  }
+}
+
+export default a11yFixes;


### PR DESCRIPTION
- Minimum font size should be 12pt
- Increase contrast on Placeholder text
- ARIA roles must be contained by specific parent roles (the Fuzzy Name select menu)
- `<html>` document needs a `[lang]` attribute
- The 3 select menus (Fuzzy Name, Sources, Countries) need properly associated `<label>` tags
- Recommended by WAVE
    - Add a `<legend>` for the `<fieldset>`
    - Add 1 or more semantic regions or ARIA landmarks (like `<main>`)
- General improvement
    - Hide the header text when embedded in the iframe (since it will have its own header text)
    - We can drop jQuery if we use an Event Listener in `index.html`